### PR TITLE
Adjusted Comment on Code Execution

### DIFF
--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/Program.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/Program.cs
@@ -3,7 +3,7 @@ var app = builder.Build();
 
 app.Use(async (context, next) =>
 {
-    // Do work that doesn't write to the Response.
+    // Do work that can write to the Response.
     await next.Invoke();
     // Do logging or other work that doesn't write to the Response.
 });


### PR DESCRIPTION
The referenced code sample had the same comment both before and after the call to `await next.Invoke();`

However, you CAN write to the response before you call next.invoke, so I updated the comment to reflect the proper control flow. 

I did not create an issue for this, but can if needed.